### PR TITLE
[setting/#3] BaseVC 생성

### DIFF
--- a/SOPKATHON36/SOPKATHON36/Presentation/Base/BaseViewController.swift
+++ b/SOPKATHON36/SOPKATHON36/Presentation/Base/BaseViewController.swift
@@ -1,0 +1,71 @@
+//
+//  BaseViewController.swift
+//  SOPKATHON36
+//
+//  Created by 선영주 on 5/17/25.
+//
+import UIKit
+
+class BaseViewController: UIViewController {
+
+    private var activityIndicator: UIActivityIndicatorView?
+
+    // MARK: - LifeCycle
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configure()
+        setConstraints()
+        hideKeyboardWhenTapped()
+    }
+
+    // MARK: - Configure UI
+
+    func configure() {
+        view.backgroundColor = .bgWhite
+    }
+
+    // MARK: - Layout
+
+    func setConstraints() {}
+
+    func addSubviews(_ views: UIView...) {
+        views.forEach { view.addSubview($0) }
+    }
+
+    // MARK: - Keyboard Handling
+
+    func hideKeyboardWhenTapped() {
+        let tap = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+        tap.cancelsTouchesInView = false
+        view.addGestureRecognizer(tap)
+    }
+
+    @objc private func dismissKeyboard() {
+        view.endEditing(true)
+    }
+
+    // MARK: - Loading Indicator
+
+    func showLoading() {
+        if activityIndicator == nil {
+            activityIndicator = UIActivityIndicatorView(style: .large)
+            activityIndicator?.center = view.center
+            activityIndicator?.hidesWhenStopped = true
+            view.addSubview(activityIndicator!)
+        }
+        activityIndicator?.startAnimating()
+    }
+
+    func hideLoading() {
+        activityIndicator?.stopAnimating()
+    }
+
+    // MARK: - Alert
+
+    func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: "확인", style: .default))
+        present(alert, animated: true)
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
<!-- 해결한 이슈 번호를 작성하고 이슈가 해결되었다면 해결 여부에 체크해주세요! (Ex. #4) -->
- Connected: #3

## 📄 작업 내용
<!-- 작업한 내용을 두괄식으로 작성해주세요 -->
- 베이스뷰컨을 만들었다오

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명

함수 이름 | 역할 설명
-- | --
viewDidLoad() | 뷰컨트롤러가 메모리에 로드되고 처음 실행될 때 호출됨. configure(), setConstraints(), hideKeyboardWhenTapped()을 호출하여 화면 초기 설정, 레이아웃 구성, 키보드 처리 작업을 한 번에 수행
configure() | 화면 초기 구성 작업을 담당하는 함수. 기본 배경색을 .bgWhite로 설정하여 전체 화면의 톤을 통일함. 각 VC에서 오버라이드하여 버튼 액션 연결 등의 초기 설정도 가능
setConstraints() | SnapKit 등을 이용해 레이아웃 제약 조건을 설정하는 함수. UI 컴포넌트를 직접 ViewController에서 구성할 때 오토레이아웃을 정의하는 용도로 오버라이드됨
addSubviews() | 여러 개의 서브뷰를 간단하게 한 번에 추가할 수 있는 헬퍼 함수. 반복적인 addSubview() 호출을 줄여줌
hideKeyboardWhenTapped() | 화면을 탭했을 때 키보드를 내리는 제스처를 설정하는 함수. 텍스트 입력 후 외부 탭 시 키보드가 자동으로 내려가도록
dismissKeyboard() | hideKeyboardWhenTapped()에서 연결되는 액션 함수로, 현재 포커스를 해제하여 키보드를 내림
showLoading() | 로딩 인디케이터를 생성하고 실행함. API 요청 등 네트워크 작업 시 사용자에게 로딩 상태를 시각적으로 보여줄 수 이뜸
hideLoading() | 실행 중인 로딩 인디케이터를 종료함. 네트워크 응답이 끝났을 때 호출
showAlert(title:message:) | 기본적인 얼럿 팝업을 띄우는 함수. 에러 메시지, 확인 메시지 등 사용자 피드백을 줄 때 활용


