### PR TITLE
[Feat/#16] 익스텐션추가

### DIFF
--- a/SOPKATHON36/SOPKATHON36.xcodeproj/project.pbxproj
+++ b/SOPKATHON36/SOPKATHON36.xcodeproj/project.pbxproj
@@ -20,17 +20,29 @@
 		CB763BCC2DD64FCF0073DFCD /* Exceptions for "SOPKATHON36" folder in "SOPKATHON36" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				"Resource/Extension/UIStackView+.swift",
 				Resource/Info.plist,
 			);
 			target = CB763BB92DD64FCD0073DFCD /* SOPKATHON36 */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		78A684BA2DD8F00000ADC34E /* Exceptions for "SOPKATHON36" folder in "Copy Bundle Resources" phase from "SOPKATHON36" target */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = CB763BB82DD64FCD0073DFCD /* Resources */;
+			membershipExceptions = (
+				"Resource/Extension/UIStackView+.swift",
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		CB763BBC2DD64FCD0073DFCD /* SOPKATHON36 */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				CB763BCC2DD64FCF0073DFCD /* Exceptions for "SOPKATHON36" folder in "SOPKATHON36" target */,
+				78A684BA2DD8F00000ADC34E /* Exceptions for "SOPKATHON36" folder in "Copy Bundle Resources" phase from "SOPKATHON36" target */,
 			);
 			path = SOPKATHON36;
 			sourceTree = "<group>";

--- a/SOPKATHON36/SOPKATHON36/Resource/Extension/UIStackView+.swift
+++ b/SOPKATHON36/SOPKATHON36/Resource/Extension/UIStackView+.swift
@@ -1,0 +1,20 @@
+//
+//  UIStackView+.swift
+//
+//  Created by 이지훈 on 6/30/24.
+//
+
+import UIKit
+
+extension UIStackView {
+    convenience init(axis: NSLayoutConstraint.Axis) {
+        self.init(frame: .zero)
+        self.axis = axis
+    }
+    
+    func addArrangedSubviews(_ views: UIView...) {
+        views.forEach {
+            self.addArrangedSubview($0)
+        }
+    }
+}

--- a/SOPKATHON36/SOPKATHON36/Resource/Extension/UIView+.swift
+++ b/SOPKATHON36/SOPKATHON36/Resource/Extension/UIView+.swift
@@ -1,7 +1,26 @@
 //
 //  UIView+.swift
-//  SOPKATHON36
 //
-//  Created by 최주리 on 5/16/25.
+//  Created by 이지훈 on 6/30/24.
 //
 
+import UIKit
+
+extension UIView {
+    convenience init(backgroundColor: UIColor) {
+        self.init(frame: .zero)
+        self.backgroundColor = backgroundColor
+    }
+    
+    func addSubviews(_ views: UIView...) {
+        views.forEach {
+            addSubview($0)
+        }
+    }
+    
+    func roundCorners(cornerRadius: CGFloat, maskedCorners: CACornerMask) {
+        clipsToBounds = true
+        layer.cornerRadius = cornerRadius
+        layer.maskedCorners = CACornerMask(arrayLiteral: maskedCorners)
+    }
+}


### PR DESCRIPTION
## 🔗 연결된 이슈
- Connected: #16 

## 📄 작업 내용
-스택뷰 익스텐션 구현
- 유아이뷰 

|    구현 내용    |   IPhone 15 pro   |   IPhone SE   |
| :-------------: | :----------: | :----------: |
| GIF | <img src = "" width ="250"> | <img src = "" width ="250"> |

## 💻 주요 코드 설명

UIStackView+ 확장 사용법

1. 축(axis)을 지정하여 스택뷰 초기화
```swift
기존 방식
let verticalStack = UIStackView()
verticalStack.axis = .vertical

// 확장 사용 방식
let verticalStack = UIStackView(axis: .vertical)
```

2. 여러 뷰를 한 번에 스택뷰에 추가

```swift
let stackView = UIStackView()
stackView.addArrangedSubview(label1)
stackView.addArrangedSubview(button1)
stackView.addArrangedSubview(imageView)

// 확장 사용 방식
let stackView = UIStackView()
stackView.addArrangedSubviews(label1, button1, imageView)
```

UIView+ 확장 사용법
이 확장은 UIView를 더 쉽게 초기화하고, 여러 하위 뷰를 한 번에 추가하며, 특정 모서리만 둥글게 만드는 기능 제공

1. 배경색을 지정하여 뷰 초기화
```swift
let redView = UIView()
redView.backgroundColor = .red

// 확장 사용 방식
let redView = UIView(backgroundColor: .red)
```

2. 여러 하위 뷰를 한 번에 추가

```swift
let containerView = UIView()
containerView.addSubview(label)
containerView.addSubview(button)
containerView.addSubview(imageView)

// 확장 사용 방식
let containerView = UIView()
containerView.addSubviews(label, button, imageView)
```
3. 특정 모서리만 둥글게 만들기

```swift
let cardView = UIView()
cardView.clipsToBounds = true
cardView.layer.cornerRadius = 10
cardView.layer.maskedCorners = [.layerMinXMinYCorner, .layerMaxXMinYCorner] // 상단 모서리만 둥글게

// 확장 사용 방식
let cardView = UIView()
cardView.roundCorners(cornerRadius: 10, maskedCorners: [.layerMinXMinYCorner, .layerMaxXMinYCorner
```
